### PR TITLE
Change Text filter to highlight the substring that matches the Regexp

### DIFF
--- a/mrblib/core_ext.rb
+++ b/mrblib/core_ext.rb
@@ -1,0 +1,5 @@
+class String
+  def red
+    "\e[31m#{self}\e[0m"
+  end
+end

--- a/mrblib/rf/00filter/text.rb
+++ b/mrblib/rf/00filter/text.rb
@@ -21,10 +21,16 @@ module Rf
 
       def decorate(val)
         case val
-        when MatchData, true
+        when true
           record
         when Regexp
-          decorate(val.match(record))
+          return unless m = val.match(record)
+
+          [
+            m.pre_match,
+            m.to_s.red,
+            m.post_match
+          ].join
         when false, nil
           nil
         else

--- a/spec/filter/text_spec.rb
+++ b/spec/filter/text_spec.rb
@@ -48,12 +48,26 @@ describe 'Text filter' do
     describe 'Output only the lines that match the regexp' do
       let(:output) do
         <<~OUTPUT
-          1 foo
-          4 foobar
+          1 \e[31mfoo\e[0m
+          4 \e[31mfoo\e[0mbar
         OUTPUT
       end
 
       before { run_rf('/foo/', input) }
+
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output_on_stdout output_string_eq output }
+    end
+
+    describe 'Output only the substring that matches the regexp' do
+      let(:output) do
+        <<~OUTPUT
+          foo
+          foo
+        OUTPUT
+      end
+
+      before { run_rf('match(/foo/)', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output_on_stdout output_string_eq output }

--- a/spec/support/aruba.rb
+++ b/spec/support/aruba.rb
@@ -4,6 +4,7 @@ Aruba.configure do |config|
   # need custom working directory to avoia conflict with parallel tests
   working_directory = File.join('tmp/aruba', ENV['TEST_ENV_NUMBER'] || '1')
   config.working_directory = working_directory
+  config.remove_ansi_escape_sequences = false
 end
 
 def rf_path


### PR DESCRIPTION
textフィルタを使用時にRegexpを戻り値を指定すると、Regexpにマッチした部分のみハイライトして出力します。

![image](https://github.com/buty4649/rf/assets/1275643/16b45705-d433-498f-9d3d-24d45f137757)
