### PR TITLE
Allow passing block to match method

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,6 +63,7 @@ RSpec/ContextWording:
   Prefixes:
     - when
     - with
+    - without
     - for
 
 RSpec/DescribeClass:

--- a/mrblib/rf/container.rb
+++ b/mrblib/rf/container.rb
@@ -28,8 +28,8 @@ module Rf
     end
 
     %i[gsub gsub! match match? sub sub! tr tr!].each do |sym|
-      define_method(sym) do |*args|
-        _.__send__(sym, *args) if string?
+      define_method(sym) do |*args, &block|
+        _.__send__(sym, *args, &block) if string?
       end
     end
 

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -30,13 +30,25 @@ describe 'Method' do
   end
 
   describe '#match' do
-    let(:input) { 'foo' }
-    let(:output) { 'foo' }
+    context 'without block' do
+      let(:input) { 'foo' }
+      let(:output) { 'foo' }
 
-    before { run_rf("'match(/foo/)'", input) }
+      before { run_rf("'match(/foo/)'", input) }
 
-    it { expect(last_command_started).to be_successfully_executed }
-    it { expect(last_command_started).to have_output output_string_eq output }
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output output_string_eq output }
+    end
+
+    context 'with block' do
+      let(:input) { 'foo' }
+      let(:output) { 'bar' }
+
+      before { run_rf(%('match(/foo/) { "bar" }'), input) }
+
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output output_string_eq output }
+    end
   end
 
   describe '#match?' do


### PR DESCRIPTION
組み込みメソッドにブロックを渡せるようにします。
これにより以下のようなことができるようになります。

```sh
echo "foo" | rf 'match /foo/ { "bar" }
#=> bar
```