### PR TITLE
Add aliases for match and match? as m and m?

### DIFF
--- a/mrblib/rf/container.rb
+++ b/mrblib/rf/container.rb
@@ -33,6 +33,9 @@ module Rf
       end
     end
 
+    alias m match
+    alias m? match?
+
     %i[dig].each do |sym|
       define_method(sym) do |*args|
         _.__send__(sym, *args) if hash?

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -51,11 +51,43 @@ describe 'Method' do
     end
   end
 
+  describe '#m' do
+    context 'without block' do
+      let(:input) { 'foo' }
+      let(:output) { 'foo' }
+
+      before { run_rf("'m /foo/'", input) }
+
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output output_string_eq output }
+    end
+
+    context 'with block' do
+      let(:input) { 'foo' }
+      let(:output) { 'bar' }
+
+      before { run_rf(%('m /foo/ { "bar" }'), input) }
+
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output output_string_eq output }
+    end
+  end
+
   describe '#match?' do
     let(:input) { 'foo' }
     let(:output) { 'foo' }
 
     before { run_rf("'match?(/foo/)'", input) }
+
+    it { expect(last_command_started).to be_successfully_executed }
+    it { expect(last_command_started).to have_output output_string_eq output }
+  end
+
+  describe '#m?' do
+    let(:input) { 'foo' }
+    let(:output) { 'foo' }
+
+    before { run_rf("'m? /foo/'", input) }
 
     it { expect(last_command_started).to be_successfully_executed }
     it { expect(last_command_started).to have_output output_string_eq output }


### PR DESCRIPTION
matchとmatch?にそれぞれmとm?のエイリアスを追加します。
以下のようなことができるようになります。

```
echo "foo" | rf 'm /foo/{ "bar" }'
#=> bar

echo "foo" | rf 'm? /foo/'
#=> foo
```