### PR TITLE
Modified special variable handling in match function

### DIFF
--- a/mrblib/rf/container.rb
+++ b/mrblib/rf/container.rb
@@ -27,14 +27,23 @@ module Rf
       _.instance_of?(Hash)
     end
 
-    %i[gsub gsub! match match? sub sub! tr tr!].each do |sym|
+    %i[gsub gsub! match? sub sub! tr tr!].each do |sym|
       define_method(sym) do |*args, &block|
         _.__send__(sym, *args, &block) if string?
       end
     end
 
-    alias m match
     alias m? match?
+
+    def match(pattern)
+      regexp = pattern.is_a?(Regexp) ? pattern : Regexp.new(pattern)
+      return unless string? && m = regexp.match(_)
+
+      return m unless block_given?
+
+      yield(*fields)
+    end
+    alias m match
 
     %i[dig].each do |sym|
       define_method(sym) do |*args|

--- a/mrblib/rf/runner.rb
+++ b/mrblib/rf/runner.rb
@@ -12,6 +12,7 @@ module Rf
     # @param [Hash<String>] opts
     #   :command => String
     #   :filter => Rf::Filter
+    #   :slurp => Boolean
     #   :quiet => Boolean
     def initialize(opts)
       @command = opts[:command]

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -41,10 +41,10 @@ describe 'Method' do
     end
 
     context 'with block' do
-      let(:input) { 'foo' }
+      let(:input) { 'foo bar' }
       let(:output) { 'bar' }
 
-      before { run_rf(%('match(/foo/) { "bar" }'), input) }
+      before { run_rf(%('match(/foo/) { _2 }'), input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }
@@ -63,10 +63,10 @@ describe 'Method' do
     end
 
     context 'with block' do
-      let(:input) { 'foo' }
+      let(:input) { 'foo bar' }
       let(:output) { 'bar' }
 
-      before { run_rf(%('m /foo/ { "bar" }'), input) }
+      before { run_rf(%('m /foo/ { _2 }'), input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }


### PR DESCRIPTION
match(m)関数の中で`_1`や`_2`が意図しない値になるのを回避する。
具体的には、変更前は_1はMatchDataになり_2,_3...はnilになっていた。

```sh
# 変更前
❯ echo "abc def ghi" | ./build/bin/rf 'm /abc/ { _2 }'
```

これをrfにおける`_1`,`_2`…と同じ意味をもたせる

```sh
# 変更後
❯ echo "abc def ghi" | ./build/bin/rf 'm /abc/ { _2 }'
def
```