### PR TITLE
Enable addition to undefined variables

### DIFF
--- a/mrblib/rf/features.rb
+++ b/mrblib/rf/features.rb
@@ -19,6 +19,7 @@ module Rf
       add_features_to_float
       add_features_to_hash
       add_features_to_json
+      add_features_to_nil_class
     end
 
     def add_features_to_integer
@@ -60,6 +61,26 @@ module Rf
     def add_features_to_json
       Object.define_method(:to_json) do
         JSON.pretty_generate(self)
+      end
+    end
+
+    def add_features_to_nil_class
+      NilClass.define_method(:+) do |other|
+        if other.is_a?(Integer) || other.is_a?(Float)
+          other
+        elsif other.is_a?(String)
+          begin
+            lambda do
+              Integer(other)
+            rescue ArgumentError
+              Float(other)
+            end.call
+          rescue ArgumentError
+            other
+          end
+        else
+          raise TypeError, "no implicit conversion of nil into #{other.class}"
+        end
       end
     end
   end

--- a/spec/feature_spec.rb
+++ b/spec/feature_spec.rb
@@ -106,4 +106,32 @@ describe 'Feature' do
       it { expect(last_command_started).to have_output output_string_eq output }
     end
   end
+
+  context 'for NilClass' do
+    where do
+      {
+        '+ Integer' => {
+          input: %w[1 2 3].join("\n"),
+          output: '6'
+        },
+        '+ Float' => {
+          input: %w[1.1 2.2 3.3].join("\n"),
+          output: '6.6'
+        },
+        '+ String' => {
+          input: %w[foo bar baz].join("\n"),
+          output: 'foobarbaz'
+        }
+      }
+    end
+
+    with_them do
+      describe 'should do additions' do
+        before { run_rf("-q 's+=_1; at_exit { puts s }'", input) }
+
+        it { expect(last_command_started).to be_successfully_executed }
+        it { expect(last_command_started).to have_output output_string_eq output }
+      end
+    end
+  end
 end


### PR DESCRIPTION
関連: https://github.com/buty4649/rf/issues/37

未定義の変数(具体的にはnil)に対して加算できるようにします。
これにより事前に変数を初期化する必要がなくなります。

```sh
# 変更前
$ echo -e '1\n2\n3\n' | rf -q 's||=0; s+=_1.to_i; at_exit { puts s }'

# 変更後
$ echo -e '1\n2\n3\n' | rf -q 's+=_1.to_i; at_exit { puts s }'
```

IntegerとFloatには `-`, `*`, `/` があるが、Stringにはないので今のところ`+`のサポートだけにする。
