### PR TITLE
Improve and split option parser

### DIFF
--- a/mrblib/rf/00filter/json.rb
+++ b/mrblib/rf/00filter/json.rb
@@ -1,10 +1,16 @@
 module Rf
   module Filter
     class Json < Base
-      Config = Struct.new(:raw)
+      class << self
+        def config
+          @config ||= Struct.new(:raw).new
+        end
 
-      def self.config
-        @config ||= Config.new
+        def configure(opt)
+          opt.on('-r', '--raw-string', 'output raw strings') do
+            config.raw = true
+          end
+        end
       end
 
       def raw?

--- a/mrblib/rf/00filter/text.rb
+++ b/mrblib/rf/00filter/text.rb
@@ -1,18 +1,27 @@
 module Rf
   module Filter
     class Text < Base
-      Config = Struct.new(:fs)
+      class << self
+        def config
+          @config ||= Struct.new(:fs).new
+        end
 
-      def self.config
-        @config ||= Config.new
+        def configure(opt)
+          opt.on('-F VAL', '--filed-separator', 'set the field separator(regexp)') do |v|
+            config.fs = v
+          end
+        end
+      end
+
+      def config
+        self.class.config
       end
 
       def initialize(io)
         super()
 
         @data = io
-        fs = self.class.config.fs
-        $; = Regexp.new(fs) if fs
+        $; = Regexp.new(config.fs) if config.fs
       end
 
       def gets

--- a/mrblib/rf/00filter/yaml.rb
+++ b/mrblib/rf/00filter/yaml.rb
@@ -1,10 +1,16 @@
 module Rf
   module Filter
     class Yaml < Base
-      Config = Struct.new(:no_doc)
+      class << self
+        def config
+          @config ||= Struct.new(:no_doc).new(no_doc: true)
+        end
 
-      def self.config
-        @config ||= Config.new(no_doc: true)
+        def configure(opt)
+          opt.on('--[no-]doc', '[no] output document sperator(---) (default:--no-doc)') do |v|
+            config.no_doc = !v
+          end
+        end
       end
 
       def no_doc?

--- a/mrblib/rf/config.rb
+++ b/mrblib/rf/config.rb
@@ -6,72 +6,65 @@ module Rf
       Parser.new.parse(argv)
     end
 
-    class Parser
+    class Parser # rubocop:disable Metrics/ClassLength
       DEFAULT_FILTER_TYPE = :text
 
       def initialize
         @config = Config.new
       end
 
-      def option # rubocop:disable Metrics/AbcSize
-        @option ||= OptionParser.new do |opt|
+      def summary
+        OptionParser.new do |opt|
           opt.program_name = 'rf'
           opt.version = VERSION
           opt.release = "mruby #{MRUBY_VERSION}"
           opt.summary_indent = ' ' * 2
 
           opt.banner = <<~BANNER
-            Usage: rf [options] 'command' file ...
-                   rf [options] -f program_file file ...
+            Usage: rf [filter type] [options] 'command' file ...
+                   rf [filter type] [options] -f program_file file ...
           BANNER
 
-          opt.separator 'global options:'
-          opt.on('-t', "--type={#{Filter.types.join('|')}}",
-                 "set the type of input (default: #{DEFAULT_FILTER_TYPE})") do |v|
-            load_filter(v.to_sym)
-          end
-          opt.on('-j', '--json', 'same as -tjson') { load_filter(:json) }
-          opt.on('-y', '--yaml', 'same as -tyaml') { load_filter(:yaml) }
+          opt.separator 'filter types:'
+          opt.on('-t', "--type={#{Filter.types.join('|')}}", 'set the type of input (default: text)')
+          opt.on('-j', '--json', 'same as --type=json')
+          opt.on('-y', '--yaml', 'same as --type=yaml')
 
-          opt.on('-f', '--file=program_file', 'executed the contents of program_file') { |f| @config.script_file = f }
-          opt.on('-n', '--quiet', 'suppress automatic priting') { @config.quiet = true }
-          opt.on('-s', '--slurp', 'read all reacords into an array') { @config.slurp = true }
-          opt.on('--help', 'show this message') { print_help_and_exit }
-          opt.on('--version', 'show version') { print_version_and_exit(opt) }
-
-          add_text_options(opt)
-          add_json_options(opt)
-          add_yaml_options(opt)
+          opt.separator ''
         end
       end
 
-      def add_text_options(opt)
+      def global_options(opt = OptionParser.new)
+        opt.separator 'global options:'
+
+        opt.on('-f', '--file=program_file', 'executed the contents of program_file') { |f| @config.script_file = f }
+        opt.on('-n', '--quiet', 'suppress automatic priting') { @config.quiet = true }
+        opt.on('-s', '--slurp', 'read all reacords into an array') { @config.slurp = true }
+        opt.on('--help', 'show this message') { print_help_and_exit }
+        opt.on('--version', 'show version') { print_version_and_exit }
+      end
+
+      def filter_options(type, opt = global_options)
         opt.separator ''
-        opt.separator 'text options:'
-        opt.on('-F VAL', '--filed-separator', 'set the field separator(regexp)') do |v|
-          Filter::Text.config.fs = v
+        opt.separator "#{type} options:"
+
+        case type
+        when :text then Filter::Text.configure(opt)
+        when :json then Filter::Json.configure(opt)
+        when :yaml then Filter::Yaml.configure(opt)
         end
       end
 
-      def add_json_options(opt)
-        opt.separator ''
-        opt.separator 'json options:'
-        opt.on('-r', '--raw-string', 'output raw strings') do
-          Filter::Json.config.raw = true
+      def all_options
+        opt = global_options(summary)
+        %i[text json yaml].each do |type|
+          filter_options(type, opt)
         end
-      end
-
-      def add_yaml_options(opt)
-        opt.separator ''
-        opt.separator 'yaml options:'
-        opt.on('--[no-]doc', '[no] output document sperator(---) (default:--no-doc)') do |v|
-          Filter::Yaml.config.no_doc = !v
-        end
+        opt
       end
 
       def parse(argv)
         parameter = parse_options(argv)
-        load_filter(DEFAULT_FILTER_TYPE) unless @config.filter
 
         if @config.script_file
           @config.command = File.read(@config.script_file)
@@ -85,24 +78,56 @@ module Rf
 
       def parse_options(argv)
         print_help_and_exit(1) if argv.empty?
-        option.order(argv)
+
+        type, argv = parse_type_option(argv)
+        @config.filter = Filter.load(type)
+
+        filter_options(type).order(argv)
       end
 
-      def load_filter(type)
-        @config.filter = Filter.load(type)
+      def parse_type_option(argv)
+        argv = argv.dup
+        type = case argv.first
+               when '-t', '--type'
+                 arg, type = argv.shift(2)
+                 validate_type(arg, type)
+                 type.to_sym
+               when /^(-t)(.+)$/, /^(--type)=(.+)$/
+                 argv.shift
+                 arg = Regexp.last_match[1]
+                 type = Regexp.last_match[2]
+                 validate_type(arg, type)
+                 type.to_sym
+               when '-j', '--json'
+                 argv.shift
+                 :json
+               when '-y', '--yaml'
+                 argv.shift
+                 :yaml
+               else
+                 DEFAULT_FILTER_TYPE
+               end
+        [type, argv]
+      end
+
+      def validate_type(arg, type)
+        raise "missing argument: #{arg}" unless type
+        return if Filter.types.include?(type.to_sym)
+
+        raise %("#{type}" is invalid type. possible values: #{Filter.types.join(',')})
       end
 
       def print_help_and_exit(exit_status = 0)
         if exit_status.zero?
-          puts option.help
+          puts all_options.help
         else
-          warn option.help
+          warn all_options.help
         end
         exit exit_status
       end
 
-      def print_version_and_exit(opt)
-        puts opt.ver
+      def print_version_and_exit
+        puts all_options.ver
         exit
       end
     end

--- a/spec/filter/json_spec.rb
+++ b/spec/filter/json_spec.rb
@@ -122,7 +122,7 @@ describe 'JSON filter' do
       let(:input) { load_fixture('json/string.json') }
       let(:output) { '' }
 
-      before { run_rf('-q -j _', input) }
+      before { run_rf('-j -q _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }

--- a/spec/filter/yaml_spec.rb
+++ b/spec/filter/yaml_spec.rb
@@ -118,7 +118,7 @@ describe 'YAML filter' do
       let(:input) { load_fixture('yaml/string.yml') }
       let(:output) { '' }
 
-      before { run_rf('-q -y _', input) }
+      before { run_rf('-y -q _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }

--- a/spec/help_spec.rb
+++ b/spec/help_spec.rb
@@ -1,12 +1,14 @@
 describe 'Show help text' do
   let(:help_text) do
     <<~TEXT
-      Usage: rf [options] 'command' file ...
-             rf [options] -f program_file file ...
-      global options:
+      Usage: rf [filter type] [options] 'command' file ...
+             rf [filter type] [options] -f program_file file ...
+      filter types:
         -t, --type={text|json|yaml}      set the type of input (default: text)
-        -j, --json                       same as -tjson
-        -y, --yaml                       same as -tyaml
+        -j, --json                       same as --type=json
+        -y, --yaml                       same as --type=yaml
+
+      global options:
         -f, --file=program_file          executed the contents of program_file
         -n, --quiet                      suppress automatic priting
         -s, --slurp                      read all reacords into an array


### PR DESCRIPTION
Rf::Config::Parserですべてのオプションをパースしていたが、各フィルタの設定がRf::Config::Parserに集約してしまい関心事が増えてしまうので、各フィルタでオプションを定義するようにした。
それに合わせて、-t オプションを第1引数に設定させることにより、フィルタオプションに重複がでてもパースできるようにした。