### PR TITLE
Modified behavior of the match function

### DIFF
--- a/mrblib/rf/container.rb
+++ b/mrblib/rf/container.rb
@@ -35,11 +35,17 @@ module Rf
 
     alias m? match?
 
-    def match(pattern)
-      regexp = pattern.is_a?(Regexp) ? pattern : Regexp.new(pattern)
-      return unless string? && m = regexp.match(_)
+    def match(condition)
+      regexp = if condition.is_a?(Regexp)
+                 condition
+               elsif condition.is_a?(String)
+                 Regexp.new(condition)
+               elsif true & condition
+                 /^.*$/
+               end
+      ret = regexp&.match(_.to_s)
 
-      return m unless block_given?
+      return ret unless ret && block_given?
 
       yield(*fields)
     end

--- a/spec/filter/text_spec.rb
+++ b/spec/filter/text_spec.rb
@@ -81,7 +81,7 @@ describe 'Text filter' do
         OUTPUT
       end
 
-      before { run_rf('match(/foo/)', input) }
+      before { run_rf('_.match(/foo/)', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output_on_stdout output_string_eq output }

--- a/spec/method_spec.rb
+++ b/spec/method_spec.rb
@@ -29,47 +29,86 @@ describe 'Method' do
     it { expect(last_command_started).to have_output output_string_eq output }
   end
 
-  describe '#match' do
-    context 'without block' do
-      let(:input) { 'foo' }
-      let(:output) { 'foo' }
+  %w[match m].each do |method|
+    describe "##{method}" do
+      let(:input) do
+        <<~INPUT
+          1 foo bar
+          2 foo baz
+          3 foo qux
+        INPUT
+      end
 
-      before { run_rf("'match(/foo/)'", input) }
+      where do
+        {
+          'String' => {
+            condition: '"2 foo baz"',
+            output: {
+              without_block: '2 foo baz',
+              with_block: '2'
+            }
+          },
+          'Regexp' => {
+            condition: '/.*foo.*/',
+            output: {
+              without_block: <<~OUTPUT,
+                1 foo bar
+                2 foo baz
+                3 foo qux
+              OUTPUT
+              with_block: %w[1 2 3].join("\n")
+            }
+          },
+          'TrueClass' => {
+            condition: '_1 == "3"',
+            output: {
+              without_block: '3 foo qux',
+              with_block: 3
+            }
+          },
+          'FalseClass' => {
+            condition: '_1 == "4"',
+            output: {
+              without_block: '',
+              with_block: ''
+            }
+          },
+          'Integer' => {
+            condition: '_2 =~ /foo/',
+            output: {
+              without_block: <<~OUTPUT,
+                1 foo bar
+                2 foo baz
+                3 foo qux
+              OUTPUT
+              with_block: %w[1 2 3].join("\n")
+            }
+          },
+          'NilClass' => {
+            condition: '_2 =~ /hoge/',
+            output: {
+              without_block: '',
+              with_block: ''
+            }
+          }
+        }
+      end
 
-      it { expect(last_command_started).to be_successfully_executed }
-      it { expect(last_command_started).to have_output output_string_eq output }
-    end
+      with_them do
+        context 'without block' do
+          before { run_rf("'#{method} #{condition}'", input) }
 
-    context 'with block' do
-      let(:input) { 'foo bar' }
-      let(:output) { 'bar' }
+          it { expect(last_command_started).to be_successfully_executed }
+          it { expect(last_command_started).to have_output output_string_eq output[:without_block] }
+        end
 
-      before { run_rf(%('match(/foo/) { _2 }'), input) }
+        context 'with block' do
+          before { run_rf("'#{method} #{condition} { _1 }'", input) }
 
-      it { expect(last_command_started).to be_successfully_executed }
-      it { expect(last_command_started).to have_output output_string_eq output }
-    end
-  end
-
-  describe '#m' do
-    context 'without block' do
-      let(:input) { 'foo' }
-      let(:output) { 'foo' }
-
-      before { run_rf("'m /foo/'", input) }
-
-      it { expect(last_command_started).to be_successfully_executed }
-      it { expect(last_command_started).to have_output output_string_eq output }
-    end
-
-    context 'with block' do
-      let(:input) { 'foo bar' }
-      let(:output) { 'bar' }
-
-      before { run_rf(%('m /foo/ { _2 }'), input) }
-
-      it { expect(last_command_started).to be_successfully_executed }
-      it { expect(last_command_started).to have_output output_string_eq output }
+          it { expect(last_command_started).to be_successfully_executed }
+          it { expect(last_command_started).to have_output output_string_eq output[:with_block] }
+        end
+      end
     end
   end
 


### PR DESCRIPTION
* Values other than String and Regexp are determined as Boolean.
* Modified to match the entire string when true.

---
* 引数にStringとRegexp以外をとれるようにして、trueまたはfalseとして判定するようにした
* trueの場合全文にマッチするRegexpとして処理される

ユースケースの例として、_1が/foo/のときのみ、その行を出力する。

```
$ echo -e "foo bar\nfoo baz" | rf 'm _1 =~ /foo/'

# in awk
$ echo -e "foo bar\nfoo baz" | awk '$1 ~ /foo/'
```