### PR TITLE
Return nil for non existent Hash key

### DIFF
--- a/mrblib/rf/features.rb
+++ b/mrblib/rf/features.rb
@@ -49,12 +49,12 @@ module Rf
     end
 
     def add_features_to_hash
-      Hash.define_method(:method_missing) do |sym, *args|
-        fetch(sym.to_s) { super(sym, *args) }
+      Hash.define_method(:method_missing) do |sym, *|
+        fetch(sym.to_s, nil)
       end
 
-      Hash.define_method(:respond_to_missing?) do |sym, *|
-        key?(sym.to_s) || super
+      Hash.define_method(:respond_to_missing?) do
+        true
       end
     end
 

--- a/spec/feature_spec.rb
+++ b/spec/feature_spec.rb
@@ -88,12 +88,26 @@ describe 'Feature' do
   context 'for Hash' do
     describe 'auto accessor' do
       let(:input) { '{"foo": "bar"}' }
-      let(:output) { '"bar"' }
 
-      before { run_rf("-j '_.foo'", input) }
+      where do
+        {
+          'key is exist' => {
+            command: '_.foo',
+            output: '"bar"'
+          },
+          'key is not exist' => {
+            command: '_.piyo',
+            output: ''
+          }
+        }
+      end
 
-      it { expect(last_command_started).to be_successfully_executed }
-      it { expect(last_command_started).to have_output output_string_eq output }
+      with_them do
+        before { run_rf("-j '#{command}'", input) }
+
+        it { expect(last_command_started).to be_successfully_executed }
+        it { expect(last_command_started).to have_output output_string_eq output }
+      end
     end
   end
 


### PR DESCRIPTION
存在しないHashキーにメソッドとしてアクセスしてもraiseせずにnilを返すようにします。

```sh
# v.1.6.0
$ echo '{"foo":"bar"}' | rf -j '_.piyo'
Error: undefined method 'piyo'

# 本変更
$ echo '{"foo":"bar"}' | ./build/bin/rf -j '_.piyo'

```