### PR TITLE
refactor: simplify formatter

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -88,5 +88,5 @@ end
 
 desc 'Run RSpec with parallel_rspec'
 task 'spec' do
-  sh 'parallel_rspec --first-is-1 --serialize-stdout'
+  sh 'parallel_rspec --first-is-1'
 end

--- a/mrblib/rf/00filter/base.rb
+++ b/mrblib/rf/00filter/base.rb
@@ -1,14 +1,10 @@
 module Rf
   module Filter
     class Base
-      attr_reader :record, :index
+      attr_reader :index
 
       def initialize
         @index = 0
-      end
-
-      def decorate(val)
-        raise NotImplementedError
       end
 
       def read
@@ -16,6 +12,10 @@ module Rf
       end
 
       def gets
+        raise NotImplementedError
+      end
+
+      def format(val, record)
         raise NotImplementedError
       end
 
@@ -29,7 +29,7 @@ module Rf
               return unless v = gets_without_increment
 
               @index += 1
-              @record = v
+              v
             end
           end
 

--- a/mrblib/rf/00filter/json.rb
+++ b/mrblib/rf/00filter/json.rb
@@ -30,44 +30,17 @@ module Rf
         @data.shift
       end
 
-      def decorate(val)
-        return if quiet?(val)
-
+      def format(val, record)
         case val
         when String
           raw? ? val : val.to_json
+        when MatchData
+          record.to_json
         when Regexp
-          decorate_regexp(val)
-        when true, MatchData
-          decorate(record)
+          record.to_json if val.match?(record.to_s)
         else
           val.to_json
         end
-      end
-
-      class RegexpUnsupportType < StandardError
-        def initialize
-          super('Regexp supports only String and Number records')
-        end
-      end
-
-      def decorate_regexp(regexp)
-        raise RegexpUnsupportType unless regexp_support_type?
-        return unless regexp.match?(record.to_s)
-
-        decorate(record)
-      end
-
-      def regexp_support_type?
-        record.instance_of?(String) ||
-          record.instance_of?(Integer) ||
-          record.instance_of?(Float)
-      end
-
-      def quiet?(val)
-        # false and nil is special character in JSON
-        (val == false && record != false) ||
-          (val.nil? && !record.nil?)
       end
     end
   end

--- a/mrblib/rf/00filter/text.rb
+++ b/mrblib/rf/00filter/text.rb
@@ -23,8 +23,10 @@ module Rf
         @data.gets&.chomp
       end
 
-      def decorate(val)
+      def format(val, record)
         case val
+        when String, false, nil
+          val
         when true
           record
         when Regexp
@@ -36,9 +38,7 @@ module Rf
             m.post_match
           ].join
         when Array
-          val.map(&method(:decorate)).join(' ')
-        when false, nil
-          nil
+          val.map(&:to_s).join(' ')
         else
           val.to_s
         end

--- a/spec/feature_spec.rb
+++ b/spec/feature_spec.rb
@@ -97,7 +97,7 @@ describe 'Feature' do
           },
           'key is not exist' => {
             command: '_.piyo',
-            output: ''
+            output: 'null'
           }
         }
       end

--- a/spec/filter/json_spec.rb
+++ b/spec/filter/json_spec.rb
@@ -4,7 +4,7 @@ describe 'JSON filter' do
       let(:input) { load_fixture('json/string.json') }
       let(:output) { '"test"' }
 
-      before { run_rf('-t json true', input) }
+      before { run_rf('-t json _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }
@@ -16,7 +16,7 @@ describe 'JSON filter' do
       let(:input) { load_fixture('json/string.json') }
       let(:output) { 'test' }
 
-      before { run_rf('-j -r true', input) }
+      before { run_rf('-j -r _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }
@@ -28,7 +28,7 @@ describe 'JSON filter' do
       let(:input) { load_fixture('json/string.json') }
       let(:output) { '"test"' }
 
-      before { run_rf('-j true', input) }
+      before { run_rf('-j _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }
@@ -44,7 +44,7 @@ describe 'JSON filter' do
         OUTPUT
       end
 
-      before { run_rf('-j true', input) }
+      before { run_rf('-j _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }
@@ -109,7 +109,7 @@ describe 'JSON filter' do
 
       before do
         write_file file, input
-        run_rf("-j true #{file}")
+        run_rf("-j _ #{file}")
       end
 
       it { expect(last_command_started).to be_successfully_executed }
@@ -122,7 +122,7 @@ describe 'JSON filter' do
       let(:input) { load_fixture('json/string.json') }
       let(:output) { '' }
 
-      before { run_rf('-q -j true', input) }
+      before { run_rf('-q -j _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }
@@ -151,13 +151,19 @@ describe 'JSON filter' do
     end
 
     describe 'Input as Hash' do
-      let(:input) { load_fixture('json/hash.json') }
-      let(:output) { 'Error: Regexp supports only String and Number records' }
+      let(:input) { '{"foo": "bar"}' }
+      let(:output) do
+        <<~OUTPUT
+          {
+            "foo":"bar"
+          }
+        OUTPUT
+      end
 
       before { run_rf('-j /foo/', input) }
 
-      it { expect(last_command_started).not_to be_successfully_executed }
-      it { expect(last_command_started).to have_output_on_stderr output_string_eq output }
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output output_string_eq output }
     end
   end
 end

--- a/spec/filter/yaml_spec.rb
+++ b/spec/filter/yaml_spec.rb
@@ -4,7 +4,7 @@ describe 'YAML filter' do
       let(:input) { load_fixture('yaml/string.yml') }
       let(:output) { 'test' }
 
-      before { run_rf('-t yaml true', input) }
+      before { run_rf('-t yaml _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }
@@ -16,7 +16,7 @@ describe 'YAML filter' do
       let(:input) { load_fixture('yaml/string.yml') }
       let(:output) { 'test' }
 
-      before { run_rf('-y true', input) }
+      before { run_rf('-y _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }
@@ -42,7 +42,7 @@ describe 'YAML filter' do
         OUTPUT
       end
 
-      before { run_rf('-y true', input) }
+      before { run_rf('-y _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }
@@ -105,7 +105,7 @@ describe 'YAML filter' do
 
       before do
         write_file file, input
-        run_rf("-y true #{file}")
+        run_rf("-y _ #{file}")
       end
 
       it { expect(last_command_started).to be_successfully_executed }
@@ -118,7 +118,7 @@ describe 'YAML filter' do
       let(:input) { load_fixture('yaml/string.yml') }
       let(:output) { '' }
 
-      before { run_rf('-q -y true', input) }
+      before { run_rf('-q -y _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }
@@ -147,13 +147,13 @@ describe 'YAML filter' do
     end
 
     describe 'Input as Hash' do
-      let(:input) { load_fixture('yaml/hash.yml') }
-      let(:output) { 'Error: Regexp supports only String and Number records' }
+      let(:input) { 'foo: bar' }
+      let(:output) { input }
 
       before { run_rf('-y /foo/', input) }
 
-      it { expect(last_command_started).not_to be_successfully_executed }
-      it { expect(last_command_started).to have_output_on_stderr output_string_eq output }
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output output_string_eq output }
     end
   end
 
@@ -162,7 +162,7 @@ describe 'YAML filter' do
       let(:input) { load_fixture('yaml/string.yml') }
       let(:output) { '--- test' }
 
-      before { run_rf('-y --doc true', input) }
+      before { run_rf('-y --doc _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }
@@ -183,7 +183,7 @@ describe 'YAML filter' do
         OUTPUT
       end
 
-      before { run_rf('-y --doc true', input) }
+      before { run_rf('-y --doc _', input) }
 
       it { expect(last_command_started).to be_successfully_executed }
       it { expect(last_command_started).to have_output output_string_eq output }


### PR DESCRIPTION
出力の際に行っていた各filterでの整形をシンプルにした。
今までfilter内部の `@record` に依存していたがこれに依存しないようにした。