### PR TITLE
Replace --debug option with $RF_DEBUG environment variable

### DIFF
--- a/mrblib/rf/cli.rb
+++ b/mrblib/rf/cli.rb
@@ -18,7 +18,7 @@ module Rf
     end
 
     def debug?
-      config&.debug
+      ENV.fetch('RF_DEBUG', nil)
     end
 
     def io

--- a/mrblib/rf/config.rb
+++ b/mrblib/rf/config.rb
@@ -1,6 +1,6 @@
 module Rf
   class Config
-    attr_accessor :command, :debug, :files, :filter, :slurp, :script_file, :quiet
+    attr_accessor :command, :files, :filter, :slurp, :script_file, :quiet
 
     def self.parse(argv)
       Parser.new.parse(argv)
@@ -36,7 +36,6 @@ module Rf
           opt.on('-f', '--file=program_file', 'executed the contents of program_file') { |f| @config.script_file = f }
           opt.on('-n', '--quiet', 'suppress automatic priting') { @config.quiet = true }
           opt.on('-s', '--slurp', 'read all reacords into an array') { @config.slurp = true }
-          opt.on('--debug', 'enable debug mode') { @config.debug = true }
           opt.on('--help', 'show this message') { print_help_and_exit }
           opt.on('--version', 'show version') { print_version_and_exit(opt) }
 

--- a/spec/error_message_spec.rb
+++ b/spec/error_message_spec.rb
@@ -86,7 +86,11 @@ describe 'Show error message' do
       OUTPUT
     end
 
-    before { run_rf('--debug if', input) }
+    before do
+      ENV['RF_DEBUG'] = 'y'
+      run_rf('if', input)
+      ENV['RF_DEBUG'] = nil
+    end
 
     it { expect(last_command_started).not_to be_successfully_executed }
     it { expect(last_command_started).to have_output_on_stderr include_output_string error_message }

--- a/spec/help_spec.rb
+++ b/spec/help_spec.rb
@@ -10,7 +10,6 @@ describe 'Show help text' do
         -f, --file=program_file          executed the contents of program_file
         -n, --quiet                      suppress automatic priting
         -s, --slurp                      read all reacords into an array
-            --debug                      enable debug mode
             --help                       show this message
             --version                    show version
 


### PR DESCRIPTION
オプションをパースする前にraiseすると--debugを指定してもバックトレースが表示されない。
そのため、デバッグ表示の切り替えを環境変数に変更する。