### PR TITLE
Change delimiter in text filter from space to newline

### DIFF
--- a/mrblib/rf/00filter/text.rb
+++ b/mrblib/rf/00filter/text.rb
@@ -34,7 +34,7 @@ module Rf
             m.post_match
           ].join
         when Array
-          val.map(&:to_s).join(' ')
+          val.map(&:to_s).join("\n")
         else
           val.to_s
         end

--- a/spec/filter/text_spec.rb
+++ b/spec/filter/text_spec.rb
@@ -117,7 +117,7 @@ describe 'Text filter' do
     end
 
     describe 'Read all at once' do
-      let(:output) { input.chomp.gsub("\n", ' ') }
+      let(:output) { input }
 
       before { run_rf('-s "_"', input) }
 
@@ -180,7 +180,7 @@ describe 'Text filter' do
 
   describe 'Output the array is automatically joined with the spaces' do
     let(:input) { 'foo,bar,baz' }
-    let(:output) { 'foo bar baz' }
+    let(:output) { %w[foo bar baz].join("\n") }
 
     before { run_rf('-F, $F', input) }
 


### PR DESCRIPTION
テキストフィルタにおいてArrayを結合する文字を ` ` から `\n` に変えた。
これは--slurpオプションでArrayで入力したときに、そのまま同じ出力ができるようにするためである。