### PR TITLE
Add --disable-boolean-mode option

### DIFF
--- a/mrblib/rf/00filter/yaml.rb
+++ b/mrblib/rf/00filter/yaml.rb
@@ -3,14 +3,18 @@ module Rf
     class Yaml < Base
       class << self
         def config
-          @config ||= Struct.new(:raw, :no_doc).new.tap do |config|
+          @config ||= Struct.new(:raw, :no_doc, :boolean_mode).new.tap do |config|
             config.no_doc = true
+            config.boolean_mode = true
           end
         end
 
         def configure(opt)
           opt.on('-r', '--raw-string', 'output raw strings') do
             config.raw = true
+          end
+          opt.on('--disable-boolean-mode', 'consider true/false/null as yaml literal') do
+            config.boolean_mode = false
           end
           opt.on('--[no-]doc', '[no] output document sperator(---) (default:--no-doc)') do |v|
             config.no_doc = !v
@@ -24,6 +28,10 @@ module Rf
 
       def no_doc?
         self.class.config.no_doc
+      end
+
+      def boolean_mode?
+        self.class.config.boolean_mode
       end
 
       def initialize(io)
@@ -42,10 +50,10 @@ module Rf
       end
 
       def format(val, record)
-        return unless result = obj_to_yaml(val, record)
+        return unless yaml_obj = obj_to_yaml(val, record)
 
         unpack_unicode_escape(
-          no_doc? ? remove_doc_header(result) : result
+          no_doc? ? remove_doc_header(yaml_obj) : yaml_obj
         )
       end
 
@@ -56,11 +64,19 @@ module Rf
         when MatchData
           record.to_yaml
         when Regexp
-          record.to_yaml if val.match?(record.to_s)
-        when nil
-          '--- null'
+          val.match(record.to_s) { record.to_yaml }
+        when true, false, nil
+          boolean_or_nil_to_yaml(val, record)
         else
           val.to_yaml
+        end
+      end
+
+      def boolean_or_nil_to_yaml(boolean_or_nil, record)
+        if boolean_mode?
+          record.to_yaml if boolean_or_nil == true
+        else
+          boolean_or_nil.to_yaml
         end
       end
 

--- a/spec/feature_spec.rb
+++ b/spec/feature_spec.rb
@@ -93,17 +93,17 @@ describe 'Feature' do
         {
           'key is exist' => {
             command: '_.foo',
-            output: '"bar"'
+            output: 'bar'
           },
           'key is not exist' => {
-            command: '_.piyo',
-            output: 'null'
+            command: '_.piyo.class.to_s',
+            output: 'NilClass'
           }
         }
       end
 
       with_them do
-        before { run_rf("-j '#{command}'", input) }
+        before { run_rf("-j -r '#{command}'", input) }
 
         it { expect(last_command_started).to be_successfully_executed }
         it { expect(last_command_started).to have_output output_string_eq output }

--- a/spec/filter/json_spec.rb
+++ b/spec/filter/json_spec.rb
@@ -23,6 +23,34 @@ describe 'JSON filter' do
     end
   end
 
+  context 'with --disable-boolean-mode option' do
+    let(:input) { '"foobar"' }
+
+    where do
+      {
+        'TrueClass' => {
+          command: 'true',
+          output: 'true'
+        },
+        'FalseClass' => {
+          command: 'false',
+          output: 'false'
+        },
+        'NilClass' => {
+          command: 'nil',
+          output: 'null'
+        }
+      }
+    end
+
+    with_them do
+      before { run_rf("-j --disable-boolean-mode '#{command}'", input) }
+
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output output_string_eq output }
+    end
+  end
+
   context 'when input from stdin' do
     describe 'Output string' do
       let(:input) { load_fixture('json/string.json') }

--- a/spec/filter/yaml_spec.rb
+++ b/spec/filter/yaml_spec.rb
@@ -202,9 +202,37 @@ describe 'YAML filter' do
     end
   end
 
+  context 'with --disable-boolean-mode option' do
+    let(:input) { 'foobar' }
+
+    where do
+      {
+        'TrueClass' => {
+          command: 'true',
+          output: 'true'
+        },
+        'FalseClass' => {
+          command: 'false',
+          output: 'false'
+        },
+        'NilClass' => {
+          command: 'nil',
+          output: '~'
+        }
+      }
+    end
+
+    with_them do
+      before { run_rf("-y --disable-boolean-mode '#{command}'", input) }
+
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output output_string_eq output }
+    end
+  end
+
   describe 'Output nil value' do
     let(:input) { 'foobar' }
-    let(:output) { 'null' }
+    let(:output) { '' }
 
     before { run_rf('-y nil', input) }
 

--- a/spec/help_spec.rb
+++ b/spec/help_spec.rb
@@ -20,9 +20,11 @@ describe 'Show help text' do
 
       json options:
         -r, --raw-string                 output raw strings
+            --disable-boolean-mode       consider true/false/null as json literal
 
       yaml options:
         -r, --raw-string                 output raw strings
+            --disable-boolean-mode       consider true/false/null as yaml literal
             --[no-]doc                   [no] output document sperator(---) (default:--no-doc)
     TEXT
   end


### PR DESCRIPTION
true/false/nilをJSON/YAMLの特別なリテラルとして扱うオプションを追加。

このオプションをつけない場合は、textフィルタと同じ動作になりcommandの実行結果が
* trueの場合はrecordを返す
* false/nilの場合は何も返さない
という動作になる。