### PR TITLE
Add --with-filename option

### DIFF
--- a/mrblib/rf/cli.rb
+++ b/mrblib/rf/cli.rb
@@ -4,13 +4,13 @@ module Rf
 
     def run(argv)
       @config = Config.parse(argv)
-      Rf.add_features
       Runner.run({
                    command: config.command,
                    files: config.files,
                    filter: config.filter,
                    slurp: config.slurp,
-                   quiet: config.quiet
+                   quiet: config.quiet,
+                   with_filename: config.with_filename
                  })
     rescue NotFound => e
       print_exception_and_exit(e, false)

--- a/mrblib/rf/config.rb
+++ b/mrblib/rf/config.rb
@@ -1,6 +1,6 @@
 module Rf
   class Config
-    attr_accessor :command, :files, :filter, :slurp, :script_file, :quiet
+    attr_accessor :command, :files, :filter, :slurp, :script_file, :quiet, :with_filename
 
     def self.parse(argv)
       Parser.new.parse(argv)
@@ -87,6 +87,7 @@ module Rf
 
       def global_options
         @global_options ||= OptionMap.new do |opt|
+          opt.on('-H', '--with-filename', 'print filename with output lines') { @config.with_filename = true }
           opt.on('-f', '--file=program_file', 'executed the contents of program_file') { |f| @config.script_file = f }
           opt.on('-n', '--quiet', 'suppress automatic priting') { @config.quiet = true }
           opt.on('-s', '--slurp', 'read all reacords into an array') { @config.slurp = true }

--- a/mrblib/rf/container.rb
+++ b/mrblib/rf/container.rb
@@ -1,5 +1,12 @@
 module Rf
   class Container
+    attr_accessor :filename, :with_filename
+
+    def initialize(opts = {})
+      @filenem = opts[:filename]
+      @with_filename = opts[:with_filename] || false
+    end
+
     def _
       $_
     end
@@ -25,6 +32,11 @@ module Rf
 
     def hash?
       _.instance_of?(Hash)
+    end
+
+    def puts(*)
+      $stdout.write("#{filename}: ") if with_filename && filename
+      $stdout.puts(*)
     end
 
     %i[gsub gsub! sub sub! tr tr!].each do |sym|

--- a/spec/filter/json_spec.rb
+++ b/spec/filter/json_spec.rb
@@ -51,6 +51,55 @@ describe 'JSON filter' do
     end
   end
 
+  context 'when use -H option' do
+    let(:input) { '"foobar"' }
+    let(:output) do
+      input.split("\n").map { |line| "testfile: #{line}" }.join("\n")
+    end
+
+    before do
+      write_file 'testfile', input
+      run_rf('-j -H true testfile')
+    end
+
+    it { expect(last_command_started).to be_successfully_executed }
+    it { expect(last_command_started).to have_output_on_stdout output_string_eq output }
+  end
+
+  context 'when multiple files' do
+    let(:input) { '"foobar"' }
+
+    where do
+      {
+        'without -H option' => {
+          option: '',
+          output: <<~OUTPUT
+            "foobar"
+            "foobar"
+          OUTPUT
+        },
+        'with -H option' => {
+          option: '-H',
+          output: <<~OUTPUT
+            testfile1: "foobar"
+            testfile2: "foobar"
+          OUTPUT
+        }
+      }
+    end
+
+    with_them do
+      before do
+        write_file 'testfile1', input
+        write_file 'testfile2', input
+        run_rf("-j #{option} 'true' testfile1 testfile2")
+      end
+
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output output_string_eq output }
+    end
+  end
+
   context 'when input from stdin' do
     describe 'Output string' do
       let(:input) { load_fixture('json/string.json') }

--- a/spec/filter/text_spec.rb
+++ b/spec/filter/text_spec.rb
@@ -33,6 +33,38 @@ describe 'Text filter' do
     end
   end
 
+  context 'when use -H option' do
+    let(:output) do
+      input.split("\n").map { |line| "testfile: #{line}" }.join("\n")
+    end
+
+    before do
+      write_file 'testfile', input
+      run_rf('-H true testfile')
+    end
+
+    it { expect(last_command_started).to be_successfully_executed }
+    it { expect(last_command_started).to have_output_on_stdout output_string_eq output }
+  end
+
+  context 'when multiple files' do
+    let(:output) do
+      [
+        input.split("\n").map { |line| "testfile1: #{line}" }.join("\n"),
+        input.split("\n").map { |line| "testfile2: #{line}" }.join("\n")
+      ].join("\n")
+    end
+
+    before do
+      write_file 'testfile1', input
+      write_file 'testfile2', input
+      run_rf('true testfile1 testfile2')
+    end
+
+    it { expect(last_command_started).to be_successfully_executed }
+    it { expect(last_command_started).to have_output_on_stdout output_string_eq output }
+  end
+
   context 'when input from stdin' do
     describe 'Output all lines' do
       let(:output) { input }

--- a/spec/filter/yaml_spec.rb
+++ b/spec/filter/yaml_spec.rb
@@ -234,6 +234,55 @@ describe 'YAML filter' do
     end
   end
 
+  context 'when use -H option' do
+    let(:input) { 'foobar' }
+    let(:output) do
+      input.split("\n").map { |line| "testfile: #{line}" }.join("\n")
+    end
+
+    before do
+      write_file 'testfile', input
+      run_rf('-y -H true testfile')
+    end
+
+    it { expect(last_command_started).to be_successfully_executed }
+    it { expect(last_command_started).to have_output_on_stdout output_string_eq output }
+  end
+
+  context 'when multiple files' do
+    let(:input) { 'foobar' }
+
+    where do
+      {
+        'without -H option' => {
+          option: '',
+          output: <<~OUTPUT
+            foobar
+            foobar
+          OUTPUT
+        },
+        'with -H option' => {
+          option: '-H',
+          output: <<~OUTPUT
+            testfile1: foobar
+            testfile2: foobar
+          OUTPUT
+        }
+      }
+    end
+
+    with_them do
+      before do
+        write_file 'testfile1', input
+        write_file 'testfile2', input
+        run_rf("-y #{option} 'true' testfile1 testfile2")
+      end
+
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output output_string_eq output }
+    end
+  end
+
   describe 'Output nil value' do
     let(:input) { 'foobar' }
     let(:output) { '' }

--- a/spec/help_spec.rb
+++ b/spec/help_spec.rb
@@ -9,6 +9,7 @@ describe 'Show help text' do
         -y, --yaml                       same as --type=yaml
 
       global options:
+        -H, --with-filename              print filename with output lines
         -f, --file=program_file          executed the contents of program_file
         -n, --quiet                      suppress automatic priting
         -s, --slurp                      read all reacords into an array


### PR DESCRIPTION
出力の先頭にファイル名を追記するオプションを追加します。
textフィルタでかつ複数の入力ファイルが指定されていた場合はデフォルトで有効になります。

```sh
$ ./build/bin/rf true a b
a: foo
b: bar
```