### PR TITLE
Add --grep option

### DIFF
--- a/mrblib/rf/cli.rb
+++ b/mrblib/rf/cli.rb
@@ -8,6 +8,7 @@ module Rf
                    command: config.command,
                    files: config.files,
                    filter: config.filter,
+                   grep_mode: config.grep_mode,
                    inlude_filename: config.inlude_filename,
                    slurp: config.slurp,
                    quiet: config.quiet,

--- a/mrblib/rf/config.rb
+++ b/mrblib/rf/config.rb
@@ -1,7 +1,7 @@
 module Rf
   class Config
-    attr_accessor :command, :files, :filter, :inlude_filename, :slurp, :script_file,
-                  :quiet, :recursive, :with_filename
+    attr_accessor :command, :files, :filter, :grep_mode, :inlude_filename,
+                  :slurp, :script_file, :quiet, :recursive, :with_filename
 
     def self.parse(argv)
       Parser.new.parse(argv)
@@ -98,6 +98,9 @@ module Rf
             @config.inlude_filename = p
           end
           opt.on('-f', '--file=program_file', 'executed the contents of program_file') { |f| @config.script_file = f }
+          opt.on('-g', '--grep', 'Interpret command as a regex pattern for searching (like grep)') do
+            @config.grep_mode = true
+          end
           opt.on('-n', '--quiet', 'suppress automatic priting') { @config.quiet = true }
           opt.on('-s', '--slurp', 'read all reacords into an array') { @config.slurp = true }
           opt.on('--help', 'show this message') { print_help_and_exit }

--- a/spec/filter/json_spec.rb
+++ b/spec/filter/json_spec.rb
@@ -90,6 +90,22 @@ describe 'JSON filter' do
     it { expect(last_command_started).to have_output output_string_eq output }
   end
 
+  context 'with -g option' do
+    let(:input) { '"foo"' }
+    let(:output) { '"foo"' }
+
+    where(:command) do
+      %w[-g --grep]
+    end
+
+    with_them do
+      before { run_rf("-j #{command} .", input) }
+
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output_on_stdout output_string_eq output }
+    end
+  end
+
   context 'when multiple files' do
     let(:input) { '"foobar"' }
 

--- a/spec/filter/text_spec.rb
+++ b/spec/filter/text_spec.rb
@@ -68,6 +68,22 @@ describe 'Text filter' do
     it { expect(last_command_started).to have_output output_string_eq output }
   end
 
+  context 'with -g option' do
+    let(:input) { 'foo' }
+    let(:output) { 'foo' }
+
+    where(:command) do
+      %w[-g --grep]
+    end
+
+    with_them do
+      before { run_rf("#{command} --no-color .", input) }
+
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output_on_stdout output_string_eq output }
+    end
+  end
+
   context 'when multiple files' do
     let(:output) do
       [

--- a/spec/filter/yaml_spec.rb
+++ b/spec/filter/yaml_spec.rb
@@ -49,6 +49,22 @@ describe 'YAML filter' do
     it { expect(last_command_started).to have_output output_string_eq output }
   end
 
+  context 'with -g option' do
+    let(:input) { 'foo' }
+    let(:output) { 'foo' }
+
+    where(:command) do
+      %w[-g --grep]
+    end
+
+    with_them do
+      before { run_rf("-y #{command} .", input) }
+
+      it { expect(last_command_started).to be_successfully_executed }
+      it { expect(last_command_started).to have_output_on_stdout output_string_eq output }
+    end
+  end
+
   context 'when input from stdin' do
     describe 'Output string' do
       let(:input) { load_fixture('yaml/string.yml') }

--- a/spec/help_spec.rb
+++ b/spec/help_spec.rb
@@ -13,6 +13,7 @@ describe 'Show help text' do
         -R, --recursive                  read all files under each directory recursively
             --include-filename           searches for files matching a regex pattern
         -f, --file=program_file          executed the contents of program_file
+        -g, --grep                       Interpret command as a regex pattern for searching (like grep)
         -n, --quiet                      suppress automatic priting
         -s, --slurp                      read all reacords into an array
             --help                       show this message


### PR DESCRIPTION
grepのような挙動を行うオプションを追加します。
例えば以下のような動作をします。

```sh
$ cat foo
bar
$ rf --grep . foo
bar

# 以下と同じです
$ rf /./ foo
```