### PR TITLE
Add direct comparison between String and numeric types

### DIFF
--- a/mrblib/rf/features.rb
+++ b/mrblib/rf/features.rb
@@ -17,6 +17,7 @@ module Rf
     def add_features
       add_features_to_integer
       add_features_to_float
+      add_features_to_string
       add_features_to_hash
       add_features_to_json
       add_features_to_nil_class
@@ -24,10 +25,27 @@ module Rf
 
     def add_features_to_integer
       extend_op(Integer, :to_i)
+      compare_with_string(Integer, :try_to_i)
     end
 
     def add_features_to_float
       extend_op(Float, :to_f)
+      compare_with_string(Float, :try_to_f)
+    end
+
+    def add_features_to_string
+      %i[< <= > >=].each do |op|
+        String.define_method(op) do |other|
+          s = if other.is_a?(Integer)
+                try_to_i || self
+              elsif other.is_a?(Float)
+                try_to_f || self
+              else
+                self
+              end
+          s.method(op).super_method.call(other)
+        end
+      end
     end
 
     def extend_op(klass, convert_method)
@@ -44,6 +62,19 @@ module Rf
                 other
               end
           __send__(alias_name, o)
+        end
+      end
+    end
+
+    def compare_with_string(klass, convert_method)
+      %i[< <= > >=].each do |op|
+        klass.define_method(op) do |other|
+          o = if other.respond_to?(convert_method)
+                other.__send__(convert_method) || other
+              else
+                other
+              end
+          method(op).super_method.call(o)
         end
       end
     end

--- a/spec/feature/integaer_float_spec.rb
+++ b/spec/feature/integaer_float_spec.rb
@@ -1,26 +1,44 @@
-describe 'Extended addition feature for Integer and Float' do
-  where(:case_name, :args, :expect_output) do
-    def random_number(klass)
-      number = rand(100)
-      klass == 'Float' ? number.to_f : number
+%i[Integer Float].each do |klass|
+  describe "#{klass} class features" do
+    where(:case_name, :args, :expect_output) do
+      %w[+ - * /].map do |mark|
+        left = random_number(klass)
+        statement = %(#{left} #{mark} "1")
+        answer = left.__send__(mark, 1)
+
+        [
+          "##{mark} with String argument",
+          %('#{statement}'),
+          answer.to_s
+        ]
+      end
     end
 
-    %w[Integer Float].product(%w[+ - * /]).map do |klass, mark|
-      left = random_number(klass)
-      statement = %(#{left} #{mark} "1")
-      answer = left.__send__(mark, 1)
+    with_them do
+      let(:input) { '' }
 
-      [
-        "#{klass}#+ with String argument",
-        %('#{statement}'),
-        answer.to_s
-      ]
+      it_behaves_like 'a successful exec', input: '1'
     end
-  end
 
-  with_them do
-    let(:input) { '' }
+    where(:case_name, :args, :expect_output) do
+      %i[< <= > >=].map do |mark|
+        left = random_number(klass)
+        right = random_number(klass)
+        statement = %(#{left} #{mark} "#{right}")
+        answer = left.__send__(mark, right)
 
-    it_behaves_like 'a successful exec', input: '1'
+        [
+          "##{mark} with String argument",
+          %(-q 'p #{statement}'),
+          answer.to_s
+        ]
+      end
+    end
+
+    with_them do
+      let(:input) { '' }
+
+      it_behaves_like 'a successful exec', input: '1'
+    end
   end
 end

--- a/spec/feature/string_spec.rb
+++ b/spec/feature/string_spec.rb
@@ -1,0 +1,24 @@
+describe 'String class features' do
+  %i[Integer Float].each do |klass|
+    where(:case_name, :args, :expect_output) do
+      %i[< <= > >=].map do |mark|
+        left = random_number(klass)
+        right = random_number(klass)
+        statement = %("#{left}" #{mark} #{right})
+        answer = left.__send__(mark, right)
+
+        [
+          "##{mark} with #{klass} argument",
+          %(-q 'p #{statement}'),
+          answer.to_s
+        ]
+      end
+    end
+
+    with_them do
+      let(:input) { '' }
+
+      it_behaves_like 'a successful exec', input: '1'
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,3 +21,8 @@ end
 def windows?
   /mswin(?!ce)|mingw|cygwin|bccwin/.match?(RUBY_PLATFORM)
 end
+
+def random_number(klass)
+  number = rand(100)
+  klass == Float ? number.to_f : number
+end


### PR DESCRIPTION
resolv: #119 

文字列とInteger/Floatを直接比較できるようにします。
以下のような事ができるようになります。

```ruby
1 > "0"
#=> true

1.0 < "0"
#=> false

"100" > 1
#=> true
```