### PR TITLE
Improved runtime performance by adding build-time optimization options

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -96,7 +96,7 @@ if build_targets.include?('windows-amd64')
 
     [conf.cc, conf.linker].each do |cc|
       cc.command = "#{conf.host_target}-gcc-posix"
-      cc.flags += %w[-static -O3 -mtune=native -march=native]
+      cc.flags += %w[-static -O3]
     end
     conf.cc.defines      += %w[MRB_STR_LENGTH_MAX=0 MRB_UTF8_STRING MRUBY_YAML_NO_CANONICAL_NULL]
     conf.cxx.command      = "#{conf.host_target}-g++"

--- a/build_config.rb.lock
+++ b/build_config.rb.lock
@@ -85,6 +85,11 @@ builds:
       branch: master
       commit: bb773da39517f3ae7232538c7e9c476d45f3d9b7
       version: 0.0.0
+    https://github.com/mrbgems/mruby-tempfile.git:
+      url: https://github.com/mrbgems/mruby-tempfile.git
+      branch: master
+      commit: 48073012c932f540dc3773b2dc6b079caf71a70d
+      version: 0.0.0
   linux-arm64:
     https://github.com/mattn/mruby-json.git:
       url: https://github.com/mattn/mruby-json.git
@@ -120,6 +125,11 @@ builds:
       url: https://github.com/ksss/mruby-file-stat.git
       branch: master
       commit: bb773da39517f3ae7232538c7e9c476d45f3d9b7
+      version: 0.0.0
+    https://github.com/mrbgems/mruby-tempfile.git:
+      url: https://github.com/mrbgems/mruby-tempfile.git
+      branch: master
+      commit: 48073012c932f540dc3773b2dc6b079caf71a70d
       version: 0.0.0
   darwin-amd64:
     https://github.com/mattn/mruby-json.git:
@@ -157,6 +167,11 @@ builds:
       branch: master
       commit: bb773da39517f3ae7232538c7e9c476d45f3d9b7
       version: 0.0.0
+    https://github.com/mrbgems/mruby-tempfile.git:
+      url: https://github.com/mrbgems/mruby-tempfile.git
+      branch: master
+      commit: 48073012c932f540dc3773b2dc6b079caf71a70d
+      version: 0.0.0
   darwin-arm64:
     https://github.com/mattn/mruby-json.git:
       url: https://github.com/mattn/mruby-json.git
@@ -192,6 +207,11 @@ builds:
       url: https://github.com/ksss/mruby-file-stat.git
       branch: master
       commit: bb773da39517f3ae7232538c7e9c476d45f3d9b7
+      version: 0.0.0
+    https://github.com/mrbgems/mruby-tempfile.git:
+      url: https://github.com/mrbgems/mruby-tempfile.git
+      branch: master
+      commit: 48073012c932f540dc3773b2dc6b079caf71a70d
       version: 0.0.0
   windows-amd64:
     https://github.com/mattn/mruby-json.git:


### PR DESCRIPTION
ビルド時に最適化オプションをつけることで高速化します。

```
# before
❯ time rf -g -q hello /usr/share/dict/american-english

________________________________________________________
Executed in    7.27 secs    fish           external
   usr time    6.14 secs  420.00 micros    6.14 secs
   sys time    0.80 secs    0.00 micros    0.80 secs

# after
❯ time ./build/bin/rf -q -g hello /usr/share/dict/american-english

________________________________________________________
Executed in    1.92 secs    fish           external
   usr time    1.83 secs  192.00 micros    1.83 secs
   sys time    0.00 secs  221.00 micros    0.00 secs
```