### PR TITLE
Fix infinite loop issue when reading binary files

### DIFF
--- a/mrblib/rf/buffered_io.rb
+++ b/mrblib/rf/buffered_io.rb
@@ -21,8 +21,16 @@ module Rf
         fill_buffer if @buffer.empty?
         break if @buffer.empty?
 
-        newline_index = @buffer.index("\n")
-        if newline_index
+        if @buffer =~ /\n/
+          # bug: In the case of binary files, String#index enters an infinite loop, thus returning the entire buffer.
+          # see. https://github.com/mruby/mruby/issues/6143
+          if @binary
+            line = @buffer.slice!(0..-1)
+            @buffer.clear
+            break
+          end
+
+          newline_index = @buffer.index("\n")
           line << @buffer.slice!(0..newline_index)
           break
         else

--- a/spec/binary_file_match_spec.rb
+++ b/spec/binary_file_match_spec.rb
@@ -1,6 +1,8 @@
 describe 'Binary file match' do
+  let(:content) { "hello\x00\x80k\xb8\x00world\n" }
+
   context 'when input is from stdin' do
-    let(:input) { "hello\x00world\n" }
+    let(:input) { content }
     let(:args) { '_' }
     let(:expect_output) { 'Binary file matches.' }
 
@@ -13,7 +15,7 @@ describe 'Binary file match' do
     let(:expect_output) { 'Binary file matches.' }
 
     before do
-      write_file(file, "hello\x00world\n")
+      write_file(file, content)
     end
 
     it_behaves_like 'a successful exec'

--- a/spec/support/aruba.rb
+++ b/spec/support/aruba.rb
@@ -5,6 +5,7 @@ Aruba.configure do |config|
   working_directory = File.join('tmp/aruba', ENV['TEST_ENV_NUMBER'] || '1')
   config.working_directory = working_directory
   config.remove_ansi_escape_sequences = false
+  config.exit_timeout = 3
 end
 
 def rf_path
@@ -26,8 +27,6 @@ def run_rf(args, input = nil)
     type input.chomp
     close_input
   end
-
-  command.wait
 
   # Call the stop method here to avoid IO waiting on command output.
   # This approach efficiently handles the output processing by caching it immediately,


### PR DESCRIPTION
バイナリファイルを読ませると無限ループする問題を修正します。
see. https://github.com/mruby/mruby/issues/6143