### PR TITLE
Change non-existent method behavior to NoMethodError for clarity

### DIFF
--- a/mrblib/rf/container.rb
+++ b/mrblib/rf/container.rb
@@ -2,6 +2,12 @@ $output = $stdout
 
 module Rf
   class Container
+    class NoMethodError < StandardError
+      def initialize(sym)
+        super("undefined method `#{sym}'. Record is an instance of #{Record.class}}")
+      end
+    end
+
     attr_accessor :filename
 
     def initialize(opts = {})
@@ -60,21 +66,19 @@ module Rf
       end.join
     end
 
-    %i[gsub gsub! sub sub! tr tr!].each do |sym|
+    %i[grep grep_v gsub gsub! sub sub!].each do |sym|
       define_method(sym) do |*args, &block|
-        _.__send__(sym, *args, &block) if string?
+        raise NoMethodError, sym unless _.respond_to?(sym)
+
+        _.__send__(sym, *args, &block)
       end
     end
 
-    %i[dig].each do |sym|
+    %i[dig tr tr!].each do |sym|
       define_method(sym) do |*args|
-        _.__send__(sym, *args) if hash?
-      end
-    end
+        raise NoMethodError, sym unless _.respond_to?(sym)
 
-    %i[grep grep_v].each do |sym|
-      define_method(sym) do |*args, &block|
-        _.__send__(sym, *args, &block) if array?
+        _.__send__(sym, *args)
       end
     end
 


### PR DESCRIPTION
Rf::Containerのエリアスメソッドは、レコードの型によってメソッドを呼び出すか、そうじゃないかを判定していた。
しかし、これだと意図せずにnilが返却されることがあり混乱のもとだった。
そこで、レコードに当該のメソッドがない場合に正しくエラーになるように変更した。