### PR TITLE
Allow infinite array size(MRB_ARY_LENGTH_MAX=0)

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -22,10 +22,15 @@ def build_config(conf, target = nil, strip: false)
     cc.command = 'zig cc'
     cc.flags += flags
   end
+  build_cc_defines(conf)
 
   conf.archiver.command = 'zig ar'
-  conf.cc.defines += %w[MRB_STR_LENGTH_MAX=0 MRB_UTF8_STRING MRUBY_YAML_NO_CANONICAL_NULL MRB_IREP_LVAR_MERGE_LIMIT=240]
   conf.host_target = target if target
+end
+
+def build_cc_defines(conf)
+  conf.cc.defines += %w[MRB_STR_LENGTH_MAX=0 MRB_UTF8_STRING MRUBY_YAML_NO_CANONICAL_NULL MRB_IREP_LVAR_MERGE_LIMIT=240
+                        MRB_ARY_LENGTH_MAX=0]
 end
 
 MRuby::Build.new do |conf|
@@ -99,8 +104,7 @@ if build_targets.include?('windows-amd64')
       cc.command = "#{conf.host_target}-gcc-posix"
       cc.flags += %w[-static -O3 -s]
     end
-    conf.cc.defines      += %w[MRB_STR_LENGTH_MAX=0 MRB_UTF8_STRING MRUBY_YAML_NO_CANONICAL_NULL
-                               MRB_IREP_LVAR_MERGE_LIMIT=240]
+    build_cc_defines(conf)
     conf.cxx.command      = "#{conf.host_target}-g++"
     conf.archiver.command = "#{conf.host_target}-gcc-ar"
 

--- a/spec/feature/array_size_spec.rb
+++ b/spec/feature/array_size_spec.rb
@@ -1,0 +1,12 @@
+describe 'Array size' do
+  let(:input) do
+    # default array size max is 131072
+    # src/array.c:21: #define MRB_ARY_LENGTH_MAX 131072
+    140_000.times.to_a.join("\n")
+  end
+
+  let(:args) { '-s _.size' }
+  let(:expect_output) { '140000' }
+
+  it_behaves_like 'a successful exec'
+end


### PR DESCRIPTION
作成できるArrayのサイズを無制限に変更した