### PR TITLE
Replace --grep option with grep command

### DIFF
--- a/mrblib/rf/cli.rb
+++ b/mrblib/rf/cli.rb
@@ -73,11 +73,15 @@ module Rf
 
     class << self
       def usage(name, command)
-        c = command || '[command]'
-        <<~USAGE
-          #{name} #{c} [options] 'code' file ...
-          #{name} #{c} [options] -f program_file file ...
-        USAGE
+        if command == :grep
+          "#{name} grep [options] pattern [file ...]"
+        else
+          c = command || '[command]'
+          <<~USAGE
+            #{name} #{c} [options] 'code' [file ...]
+            #{name} #{c} [options] -f program_file [file ...]
+          USAGE
+        end
       end
 
       def show_help_on_failure? = false

--- a/mrblib/rf/cli.rb
+++ b/mrblib/rf/cli.rb
@@ -7,8 +7,6 @@ module Rf
                          desc: '[no] colorized output (default: --color in TTY)'
     class_option :expression, type: :string, display_name: 'e', banner: "'code'", repeatable: true,
                               desc: 'evaluate the expression (can be specified multiple times)'
-    class_option :grep_mode, type: :flag, aliases: :g, display_name: 'grep',
-                             desc: 'Interpret command as a regex pattern for searching (like grep)'
     class_option :include_filename, banner: 'pattern', desc: 'searches for files matching a regex pattern'
     class_option :in_place, type: :string, aliases: :i, banner: '[=SUFFIX]',
                             desc: 'edit files in place (makes backup if SUFFIX supplied)'
@@ -32,10 +30,16 @@ module Rf
       run :text, argv
     end
 
+    desc 'grep', 'use Text filter with grep mode'
+    order 1
+    def grep(*argv)
+      run :grep, argv
+    end
+
     option :raw?, aliases: :r, display_name: 'raw-string', type: :flag
     option :minify?, display_name: 'minify', type: :flag
     desc 'json', 'use JSON filter'
-    order 1
+    order 2
     def json(*argv)
       run :json, argv
     end
@@ -43,7 +47,7 @@ module Rf
     option :raw?, aliases: :r, display_name: 'raw-string', type: :flag
     option :doc?, display_name: 'doc', type: :boolean
     desc 'yaml', 'use YAML filter'
-    order 2
+    order 3
     def yaml(*argv)
       run :yaml, argv
     end
@@ -68,7 +72,9 @@ module Rf
 
     no_commands do # rubocop:disable Metrics/BlockLength
       def run(type, argv)
-        config = Config.new(type, options, argv)
+        t = type == :grep ? :text : type
+        config = Config.new(t, options, argv)
+        config.grep_mode = type == :grep
 
         Runner.run(config)
       rescue Rf::NoExpression

--- a/mrblib/rf/cli.rb
+++ b/mrblib/rf/cli.rb
@@ -5,24 +5,23 @@ module Rf
 
     class_option :color, type: :boolean, default: $stdout.tty?,
                          desc: '[no] colorized output (default: --color in TTY)'
-    class_option :expression, type: :string, display_name: 'e', banner: "'code'", repeatable: true,
-                              desc: 'evaluate the expression (can be specified multiple times)'
     class_option :include_filename, banner: 'pattern', desc: 'searches for files matching a regex pattern'
-    class_option :in_place, type: :string, aliases: :i, banner: '[=SUFFIX]',
-                            desc: 'edit files in place (makes backup if SUFFIX supplied)'
-    class_option :recursive, type: :flag, aliases: :R,
-                             desc: 'read all files under each directory recursively'
-    class_option :script_file, type: :string, aliases: :f, display_name: 'file',
-                               desc: 'executed the contents of program_file'
-    class_option :slurp, type: :flag, aliases: :s,
-                         desc: 'read all reacords into an array'
     class_option :quiet, type: :flag, aliases: :q,
                          desc: 'suppress automatic printing'
+    class_option :recursive, type: :flag, aliases: :R,
+                             desc: 'read all files under each directory recursively'
     class_option :with_filename, type: :flag, aliases: :H,
                                  desc: 'print filename with output lines'
     class_option :with_record_number, type: :flag,
                                       desc: 'print record number with output lines'
 
+    option :expression, type: :string, display_name: 'e', banner: "'code'", repeatable: true,
+                        desc: 'evaluate the expression (can be specified multiple times)'
+    option :in_place, type: :string, aliases: :i, banner: '[=SUFFIX]',
+                      desc: 'edit files in place (makes backup if SUFFIX supplied)'
+    option :script_file, type: :string, aliases: :f, display_name: 'file',
+                         desc: 'executed the contents of program_file'
+    option :slurp, type: :flag, aliases: :s, desc: 'read all reacords into an array'
     option :filed_separator, aliases: :F
     desc 'text', 'use Text filter'
     order 0
@@ -36,6 +35,13 @@ module Rf
       run :grep, argv
     end
 
+    option :expression, type: :string, display_name: 'e', banner: "'code'", repeatable: true,
+                        desc: 'evaluate the expression (can be specified multiple times)'
+    option :in_place, type: :string, aliases: :i, banner: '[=SUFFIX]',
+                      desc: 'edit files in place (makes backup if SUFFIX supplied)'
+    option :script_file, type: :string, aliases: :f, display_name: 'file',
+                         desc: 'executed the contents of program_file'
+    option :slurp, type: :flag, aliases: :s, desc: 'read all reacords into an array'
     option :raw?, aliases: :r, display_name: 'raw-string', type: :flag
     option :minify?, display_name: 'minify', type: :flag
     desc 'json', 'use JSON filter'
@@ -44,6 +50,13 @@ module Rf
       run :json, argv
     end
 
+    option :expression, type: :string, display_name: 'e', banner: "'code'", repeatable: true,
+                        desc: 'evaluate the expression (can be specified multiple times)'
+    option :in_place, type: :string, aliases: :i, banner: '[=SUFFIX]',
+                      desc: 'edit files in place (makes backup if SUFFIX supplied)'
+    option :script_file, type: :string, aliases: :f, display_name: 'file',
+                         desc: 'executed the contents of program_file'
+    option :slurp, type: :flag, aliases: :s, desc: 'read all reacords into an array'
     option :raw?, aliases: :r, display_name: 'raw-string', type: :flag
     option :doc?, display_name: 'doc', type: :boolean
     desc 'yaml', 'use YAML filter'

--- a/mrblib/rf/config.rb
+++ b/mrblib/rf/config.rb
@@ -1,9 +1,10 @@
 module Rf
   class Config
     attr_reader :expressions, :filter, :files
+    attr_accessor :grep_mode
 
     %w[
-      color? grep_mode include_filename in_place recursive? script_file slurp?
+      color? include_filename in_place recursive? script_file slurp?
       quiet? with_filename? with_record_number?
     ].each do |name|
       s = name.delete_suffix('?').to_sym

--- a/spec/filter/grep_spec.rb
+++ b/spec/filter/grep_spec.rb
@@ -1,0 +1,145 @@
+describe 'Text filter with grep mode' do
+  let(:input) { load_fixture('text/test.txt') }
+
+  context 'with basic pattern matching' do
+    let(:args) { 'grep foo' }
+    let(:expect_output) do
+      <<~OUTPUT
+        1 foo
+        4 foobar
+      OUTPUT
+    end
+
+    it_behaves_like 'a successful exec'
+  end
+
+  context 'with regex pattern' do
+    let(:args) { 'grep "ba[rz]"' }
+    let(:expect_output) do
+      <<~OUTPUT
+        2 bar
+        3 baz
+        4 foobar
+      OUTPUT
+    end
+
+    it_behaves_like 'a successful exec'
+  end
+
+  context 'with word boundary pattern' do
+    let(:args) { 'grep "\\bbar\\b"' }
+    let(:expect_output) do
+      <<~OUTPUT
+        2 bar
+      OUTPUT
+    end
+
+    it_behaves_like 'a successful exec'
+  end
+
+  context 'with line number option' do
+    let(:args) { 'grep --with-record-number foo' }
+    let(:expect_output) do
+      <<~OUTPUT
+        1:1 foo
+        4:4 foobar
+      OUTPUT
+    end
+
+    it_behaves_like 'a successful exec'
+  end
+
+  context 'with filename option' do
+    let(:args) { 'grep -H foo testfile' }
+    let(:expect_output) do
+      <<~OUTPUT
+        testfile:1 foo
+        testfile:4 foobar
+      OUTPUT
+    end
+
+    before do
+      write_file 'testfile', input
+    end
+
+    it_behaves_like 'a successful exec'
+  end
+
+  context 'with color output' do
+    let(:args) { 'grep --color foo' }
+    let(:expect_output) do
+      <<~OUTPUT
+        1 \e[31mfoo\e[m
+        4 \e[31mfoo\e[mbar
+      OUTPUT
+    end
+
+    it_behaves_like 'a successful exec'
+  end
+
+  context 'with multiple files' do
+    let(:args) { 'grep -H foo testfile1 testfile2' }
+    let(:expect_output) do
+      <<~OUTPUT
+        testfile1:1 foo
+        testfile1:4 foobar
+        testfile2:1 foo
+        testfile2:4 foobar
+      OUTPUT
+    end
+
+    before do
+      write_file 'testfile1', input
+      write_file 'testfile2', input
+    end
+
+    it_behaves_like 'a successful exec'
+  end
+
+  context 'when no matches found' do
+    let(:args) { 'grep xyz' }
+    let(:expect_output) { '' }
+
+    it_behaves_like 'a successful exec'
+  end
+
+  context 'with recursive option' do
+    let(:args) { 'grep -R foo .' }
+    let(:expect_output) do
+      <<~OUTPUT
+        ./subdir/test.txt:1 foo
+        ./subdir/test.txt:4 foobar
+        ./test.txt:1 foo
+        ./test.txt:4 foobar
+      OUTPUT
+    end
+
+    before do
+      write_file 'test.txt', input
+      FileUtils.mkdir_p(expand_path('subdir'))
+      write_file 'subdir/test.txt', input
+      write_file 'subdir/other.log', 'no match here'
+    end
+
+    it_behaves_like 'a successful exec'
+  end
+
+  context 'with include filename pattern' do
+    let(:args) { 'grep -R --include-filename "*.txt" foo .' }
+    let(:expect_output) do
+      <<~OUTPUT
+        ./test.txt:1 foo
+        ./test.txt:4 foobar
+      OUTPUT
+    end
+
+    before do
+      write_file 'test.txt', input
+      write_file 'test.log', input
+      write_file 'other.txt', 'no match'
+    end
+
+    it_behaves_like 'a successful exec'
+  end
+
+end

--- a/spec/filter/json_spec.rb
+++ b/spec/filter/json_spec.rb
@@ -65,21 +65,6 @@ describe 'JSON filter' do
     it_behaves_like 'a successful exec'
   end
 
-  context 'with -g option' do
-    let(:input) { '"foo"' }
-    let(:output) { '"foo"' }
-
-    where(:command) do
-      %w[-g --grep]
-    end
-
-    with_them do
-      before { run_rf("json #{command} .", input) }
-
-      it { expect(last_command_started).to be_successfully_executed }
-      it { expect(last_command_started).to have_output_on_stdout output_string_eq output }
-    end
-  end
 
   context 'when multiple files' do
     let(:input) { '"foobar"' }

--- a/spec/filter/text_spec.rb
+++ b/spec/filter/text_spec.rb
@@ -45,17 +45,6 @@ describe 'Text filter' do
       it_behaves_like 'a successful exec'
     end
 
-    describe 'Use grep option without text command' do
-      let(:args) { '-g --no-color foo' }
-      let(:expect_output) do
-        <<~OUTPUT
-          1 foo
-          4 foobar
-        OUTPUT
-      end
-
-      it_behaves_like 'a successful exec'
-    end
 
     describe 'Use quiet option without text command' do
       let(:args) { '-q "s||=0; s+=_1; at_exit{ puts s }"' }
@@ -124,21 +113,6 @@ describe 'Text filter' do
     it_behaves_like 'a successful exec'
   end
 
-  context 'with -g option' do
-    let(:input) { 'foo' }
-    let(:output) { "\e[31mf\e[m\e[31mo\e[m\e[31mo\e[m" }
-
-    where(:command) do
-      %w[-g --grep]
-    end
-
-    with_them do
-      before { run_rf("text #{command} --color .", input) }
-
-      it { expect(last_command_started).to be_successfully_executed }
-      it { expect(last_command_started).to have_output_on_stdout output_string_eq output }
-    end
-  end
 
   context 'when multiple files' do
     let(:args) { 'text --no-color true testfile1 testfile2' }

--- a/spec/filter/yaml_spec.rb
+++ b/spec/filter/yaml_spec.rb
@@ -65,21 +65,6 @@ describe 'YAML filter' do
     it_behaves_like 'a successful exec'
   end
 
-  context 'with -g option' do
-    let(:input) { 'foo' }
-    let(:output) { 'foo' }
-
-    where(:command) do
-      %w[-g --grep]
-    end
-
-    with_them do
-      before { run_rf("yaml #{command} .", input) }
-
-      it { expect(last_command_started).to be_successfully_executed }
-      it { expect(last_command_started).to have_output_on_stdout output_string_eq output }
-    end
-  end
 
   context 'when input from stdin' do
     describe 'Output string' do


### PR DESCRIPTION
- Remove -g/--grep global option
- Add dedicated 'rf grep' command for pattern matching
- Separate grep functionality from text/json/yaml filters
- Improve command structure and user experience