### PR TITLE
feat: add -e option to grep mode

### DIFF
--- a/mrblib/rf/cli.rb
+++ b/mrblib/rf/cli.rb
@@ -5,6 +5,8 @@ module Rf
 
     class_option :color, type: :boolean, default: $stdout.tty?,
                          desc: '[no] colorized output (default: --color in TTY)'
+    class_option :expression, type: :string, display_name: 'e', banner: "'code'", repeatable: true,
+                              desc: 'evaluate the expression (can be specified multiple times)'
     class_option :include_filename, banner: 'pattern', desc: 'searches for files matching a regex pattern'
     class_option :quiet, type: :flag, aliases: :q,
                          desc: 'suppress automatic printing'
@@ -15,8 +17,6 @@ module Rf
     class_option :with_record_number, type: :flag,
                                       desc: 'print record number with output lines'
 
-    option :expression, type: :string, display_name: 'e', banner: "'code'", repeatable: true,
-                        desc: 'evaluate the expression (can be specified multiple times)'
     option :in_place, type: :string, aliases: :i, banner: '[=SUFFIX]',
                       desc: 'edit files in place (makes backup if SUFFIX supplied)'
     option :script_file, type: :string, aliases: :f, display_name: 'file',
@@ -36,8 +36,6 @@ module Rf
       run :grep, argv
     end
 
-    option :expression, type: :string, display_name: 'e', banner: "'code'", repeatable: true,
-                        desc: 'evaluate the expression (can be specified multiple times)'
     option :in_place, type: :string, aliases: :i, banner: '[=SUFFIX]',
                       desc: 'edit files in place (makes backup if SUFFIX supplied)'
     option :script_file, type: :string, aliases: :f, display_name: 'file',
@@ -53,8 +51,6 @@ module Rf
       run :json, argv
     end
 
-    option :expression, type: :string, display_name: 'e', banner: "'code'", repeatable: true,
-                        desc: 'evaluate the expression (can be specified multiple times)'
     option :in_place, type: :string, aliases: :i, banner: '[=SUFFIX]',
                       desc: 'edit files in place (makes backup if SUFFIX supplied)'
     option :script_file, type: :string, aliases: :f, display_name: 'file',
@@ -96,7 +92,8 @@ module Rf
       def run(type, argv)
         t = type == :grep ? :text : type
         config = Config.from(t, options, argv)
-        config.grep_mode = type == :grep
+
+        config.expressions = [Regexp.new(config.expressions.join('|'))] if type == :grep
 
         Runner.run(config)
       rescue Rf::NoExpression

--- a/mrblib/rf/config.rb
+++ b/mrblib/rf/config.rb
@@ -10,8 +10,8 @@ module Rf
       end
     end
 
-    attr_reader :expressions, :filter, :files, :formatter
-    attr_accessor :grep_mode
+    attr_accessor :expressions
+    attr_reader :filter, :files, :formatter
 
     %w[
       color? include_filename in_place recursive? invert_match?

--- a/mrblib/rf/runner.rb
+++ b/mrblib/rf/runner.rb
@@ -7,7 +7,7 @@ module Rf
     attr_reader :config, :bind, :container, :inputs
 
     %w[
-      color? expressions filter files formatter grep_mode in_place include_filename
+      color? expressions filter files formatter in_place include_filename
       invert_match? slurp? quiet? recursive? with_record_number?
     ].each do |name|
       sym = name.to_sym
@@ -140,8 +140,8 @@ module Rf
       container.fields = split(record)
       bind.eval("NR = $. = #{index}") # index is Integer
 
-      if grep_mode
-        Regexp.new(expr)
+      if expr.is_a?(Regexp)
+        expr
       else
         bind.eval(expr)
       end


### PR DESCRIPTION
Make expression option global and enable -e flag for grep subcommand. Expressions in grep mode are now treated as regular expressions.