### PR TITLE
Change Array output format from space-separated to newline-separated

### DIFF
--- a/mrblib/rf/formatter/ssv.rb
+++ b/mrblib/rf/formatter/ssv.rb
@@ -1,0 +1,24 @@
+class Array
+  def to_ssv
+    Rf::FormattedString.new(Rf::Formatter::Ssv.format(self))
+  end
+  alias to_v to_ssv
+end
+
+module Rf
+  module Formatter
+    class Ssv < Base
+      class << self
+        def format(val)
+          if val.is_a?(Array)
+            val.join(' ')
+          elsif val.respond_to?(:to_s)
+            to_s
+          else
+            NotImplementedError
+          end
+        end
+      end
+    end
+  end
+end

--- a/mrblib/rf/formatter/text.rb
+++ b/mrblib/rf/formatter/text.rb
@@ -9,7 +9,7 @@ module Rf
           when MatchResult
             matchresult_to_text(val)
           when Array
-            val.map(&:to_s).join(' ')
+            val.map(&:to_s).join("\n")
           else
             val.to_s
           end

--- a/spec/container/instance_methods_spec.rb
+++ b/spec/container/instance_methods_spec.rb
@@ -31,9 +31,9 @@ describe 'Container internal methods' do
 
   where(:command, :output) do
     'grep(/foo/)'   | 'foo'
-    'grep_v(/bar/)' | 'foo baz'
+    'grep_v(/bar/)' | "foo\nbaz"
     'grep(/foo/){|i| i + "hoge" }' | 'foohoge'
-    'grep_v(/bar/){|i| i+ "hoge" }' | 'foohoge bazhoge'
+    'grep_v(/bar/){|i| i+ "hoge" }' | "foohoge\nbazhoge"
   end
 
   with_them do

--- a/spec/filter/text_spec.rb
+++ b/spec/filter/text_spec.rb
@@ -225,7 +225,7 @@ describe 'Text filter' do
 
     describe 'Read all at once' do
       let(:args) { 'text -s "_"' }
-      let(:expect_output) { "1 foo 2 bar 3 baz 4 foobar\n" }
+      let(:expect_output) { "1 foo\n2 bar\n3 baz\n4 foobar\n" }
 
       it_behaves_like 'a successful exec'
     end
@@ -281,7 +281,7 @@ describe 'Text filter' do
   describe 'Output the array is automatically joined with the spaces' do
     let(:input) { 'foo,bar,baz' }
     let(:args) { 'text -F, $F' }
-    let(:expect_output) { "foo bar baz\n" }
+    let(:expect_output) { "foo\nbar\nbaz\n" }
 
     it_behaves_like 'a successful exec'
   end


### PR DESCRIPTION
- Array output now uses newlines instead of spaces, matching puts behavior
- Add to_ssv (to_v) method for space-separated output when needed
- Update test expectations to match new Array formatting behavior

This makes Array output consistent with Ruby's puts method while providing to_v as an explicit option for space-separated output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)