### PR TITLE
feat: improve MatchResult output formatting for capture groups

### DIFF
--- a/mrblib/rf/match_result.rb
+++ b/mrblib/rf/match_result.rb
@@ -23,7 +23,9 @@ module Rf
     end
 
     def to_s
-      @match_data.map(&:to_s).join
+      @match_data.map do |m|
+        m.size == 1 ? m[0] : m[1..]
+      end.flatten.join(' ')
     end
 
     class << self

--- a/spec/fixtures/file/text/server_names.txt
+++ b/spec/fixtures/file/text/server_names.txt
@@ -1,0 +1,4 @@
+| ID                                   | HostName       | Status | Addresses     |
+|--------------------------------------|----------------|--------|---------------|
+| bd686c0e-ef13-4b02-8693-93ba9adb5a19 | testserver-001 | ACTIVE | 192.168.100.1 |
+| d6621e37-a4cc-40a8-bf47-0fbcf8a11970 | testserver-002 | ACTIVE | 10.100.0.1    |

--- a/spec/match_result_spec.rb
+++ b/spec/match_result_spec.rb
@@ -1,0 +1,27 @@
+describe 'MatchResult' do
+  describe '#to_s' do
+    context 'without capturing' do
+      let(:input) { load_fixture('text/server_names.txt') }
+      let(:args) { %("m /testserver-001.+(?&ipv4)/") }
+      let(:expect_output) do
+        <<~OUTPUT
+          testserver-001 | ACTIVE | 192.168.100.1
+        OUTPUT
+      end
+
+      it_behaves_like 'a successful exec'
+    end
+
+    context 'with capturing' do
+      let(:input) { load_fixture('text/server_names.txt') }
+      let(:args) { %("m /(testserver-001).+((?&ipv4))/") }
+      let(:expect_output) do
+        <<~OUTPUT
+          testserver-001 192.168.100.1
+        OUTPUT
+      end
+
+      it_behaves_like 'a successful exec'
+    end
+  end
+end


### PR DESCRIPTION
- Modify to_s method to handle capture groups more intelligently
- When no captures: return full match
- When captures exist: return only captured groups joined with spaces
- Add comprehensive test coverage for both scenarios
- Include test fixture for server names data

🤖 Generated with [Claude Code](https://claude.com/claude-code)