### PR TITLE
feat: add to_base64 formatter functionality

### DIFF
--- a/build_config.rb
+++ b/build_config.rb
@@ -5,6 +5,7 @@ def gem_config(conf)
   conf.gem core: 'mruby-encoding'
 
   conf.gem mgem: 'mruby-env'
+  conf.gem mgem: 'mruby-base64'
   conf.gem github: 'mrbgems/mruby-tempfile'
   conf.gem github: 'buty4649/mruby-commit-id', branch: 'main'
   conf.gem github: 'buty4649/mruby-yyjson', branch: 'main'

--- a/build_config.rb.lock
+++ b/build_config.rb.lock
@@ -49,6 +49,11 @@ builds:
       branch: main
       commit: 1218c1ed4e6e2a371c5f1873a84d954d391c066a
       version: 1.3.0
+    https://github.com/mattn/mruby-base64.git:
+      url: https://github.com/mattn/mruby-base64.git
+      branch: master
+      commit: 0e613fc86feb993aac59b922e273cef8914f11b0
+      version: 0.0.0
   linux-amd64:
     https://github.com/iij/mruby-env.git:
       url: https://github.com/iij/mruby-env.git
@@ -95,6 +100,11 @@ builds:
       branch: main
       commit: 1218c1ed4e6e2a371c5f1873a84d954d391c066a
       version: 1.3.0
+    https://github.com/mattn/mruby-base64.git:
+      url: https://github.com/mattn/mruby-base64.git
+      branch: master
+      commit: 0e613fc86feb993aac59b922e273cef8914f11b0
+      version: 0.0.0
   linux-arm64:
     https://github.com/iij/mruby-env.git:
       url: https://github.com/iij/mruby-env.git
@@ -141,6 +151,11 @@ builds:
       branch: main
       commit: 1218c1ed4e6e2a371c5f1873a84d954d391c066a
       version: 1.3.0
+    https://github.com/mattn/mruby-base64.git:
+      url: https://github.com/mattn/mruby-base64.git
+      branch: master
+      commit: 0e613fc86feb993aac59b922e273cef8914f11b0
+      version: 0.0.0
   darwin-arm64:
     https://github.com/iij/mruby-env.git:
       url: https://github.com/iij/mruby-env.git
@@ -187,6 +202,11 @@ builds:
       branch: main
       commit: 1218c1ed4e6e2a371c5f1873a84d954d391c066a
       version: 1.3.0
+    https://github.com/mattn/mruby-base64.git:
+      url: https://github.com/mattn/mruby-base64.git
+      branch: master
+      commit: 0e613fc86feb993aac59b922e273cef8914f11b0
+      version: 0.0.0
   windows-amd64:
     https://github.com/iij/mruby-env.git:
       url: https://github.com/iij/mruby-env.git
@@ -233,3 +253,8 @@ builds:
       branch: main
       commit: 1218c1ed4e6e2a371c5f1873a84d954d391c066a
       version: 1.3.0
+    https://github.com/mattn/mruby-base64.git:
+      url: https://github.com/mattn/mruby-base64.git
+      branch: master
+      commit: 0e613fc86feb993aac59b922e273cef8914f11b0
+      version: 0.0.0

--- a/mrblib/rf/features/formattable.rb
+++ b/mrblib/rf/features/formattable.rb
@@ -8,7 +8,7 @@ module Rf
       end
 
       module Object
-        %w[json yaml].each do |type|
+        %w[base64 json yaml].each do |type|
           method_name = :"to_#{type}"
           define_method(method_name) do
             val = respond_to?(:record) ? record : self

--- a/mrblib/rf/formatter/base64.rb
+++ b/mrblib/rf/formatter/base64.rb
@@ -1,0 +1,11 @@
+module Rf
+  module Formatter
+    class Base64 < Base
+      def self.format(val)
+        return '' if val.nil?
+
+        ::Base64.encode(val.to_s)
+      end
+    end
+  end
+end

--- a/spec/features/formattable_spec.rb
+++ b/spec/features/formattable_spec.rb
@@ -39,6 +39,21 @@ describe 'Formattable features' do
 
       it_behaves_like 'a successful exec'
     end
+
+    context 'with to_base64' do
+      let(:input) { load_fixture('text/test.txt') }
+      let(:args) { 'to_base64' }
+      let(:expect_output) do
+        <<~OUTPUT
+          MSBmb28=
+          MiBiYXI=
+          MyBiYXo=
+          NCBmb29iYXI=
+        OUTPUT
+      end
+
+      it_behaves_like 'a successful exec'
+    end
   end
 
   describe 'Array formatting methods' do


### PR DESCRIPTION
- Add Base64 formatter class for encoding string values
- Integrate to_base64 method into formattable features
- Add mruby-base64 gem dependency to build configuration
- Include comprehensive test coverage for base64 encoding
- Support encoding of individual lines in text input

🤖 Generated with [Claude Code](https://claude.com/claude-code)