### PR TITLE
fix: make at_exit method return nil explicitly

### DIFF
--- a/mrblib/rf/container.rb
+++ b/mrblib/rf/container.rb
@@ -108,6 +108,7 @@ module Rf
 
     def at_exit(&block)
       @__at_exit__ ||= block
+      nil
     end
   end
 end

--- a/spec/container/instance_methods_spec.rb
+++ b/spec/container/instance_methods_spec.rb
@@ -254,4 +254,27 @@ describe 'Container internal methods' do
       end
     end
   end
+
+  describe '#at_exit' do
+    context 'when checking return value' do
+      let(:input) { 'test' }
+      let(:args) { '-q "p at_exit { }"' }
+      let(:expect_output) { "nil\n" }
+
+      it_behaves_like 'a successful exec'
+    end
+
+    context 'when block is executed on exit' do
+      let(:input) { 'test' }
+      let(:args) { '"at_exit { puts \"exit block\" }; puts \"main\""' }
+      let(:expect_output) do
+        <<~OUTPUT
+          main
+          exit block
+        OUTPUT
+      end
+
+      it_behaves_like 'a successful exec'
+    end
+  end
 end


### PR DESCRIPTION
- Modify Container#at_exit to explicitly return nil
- Align behavior with Ruby's standard at_exit method
- Add comprehensive test coverage for return value verification
- Add test for block execution on program exit
- Follow RSpec naming conventions for context descriptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)