### PR TITLE
fix: prevent infinite loop when matching empty string with regexp

### DIFF
--- a/mrblib/rf/match_result.rb
+++ b/mrblib/rf/match_result.rb
@@ -36,7 +36,7 @@ module Rf
       def from_regexp(record, regexp)
         match_data = []
         s = record.to_s
-        while m = regexp.match(s)
+        while s.length.positive? && m = regexp.match(s)
           match_data << m
           s = m.post_match
         end

--- a/spec/match_result_spec.rb
+++ b/spec/match_result_spec.rb
@@ -23,5 +23,21 @@ describe 'MatchResult' do
 
       it_behaves_like 'a successful exec'
     end
+
+    context 'with empty string and empty matching regexp' do
+      let(:input) { '' }
+      let(:args) { %("//") }
+      let(:expect_output) { '' }
+
+      it_behaves_like 'a successful exec'
+    end
+
+    context 'with empty record and zero-width assertion' do
+      let(:input) { '' }
+      let(:args) { %("/^$/") }
+      let(:expect_output) { '' }
+
+      it_behaves_like 'a successful exec'
+    end
   end
 end


### PR DESCRIPTION
fix #364 

- Add length check in MatchResult.from_regexp to prevent infinite loops
- Guard against empty string matching with zero-width regex patterns
- Ensure loop terminates when string becomes empty after match
- Add comprehensive test coverage for empty string regex scenarios
- Fix potential hang when processing records with empty content

🤖 Generated with [Claude Code](https://claude.com/claude-code)