### PR TITLE
Add Hash support to SSV formatter

### DIFF
--- a/mrblib/rf/features/formattable.rb
+++ b/mrblib/rf/features/formattable.rb
@@ -34,6 +34,11 @@ module Rf
         def to_table
           Rf::FormattedString.new(Rf::Formatter::Table.format(self))
         end
+
+        def to_ssv
+          Rf::FormattedString.new(Rf::Formatter::Ssv.format(self))
+        end
+        alias to_v to_ssv
       end
     end
   end

--- a/mrblib/rf/formatter/ssv.rb
+++ b/mrblib/rf/formatter/ssv.rb
@@ -5,6 +5,8 @@ module Rf
         def format(val)
           if val.is_a?(Array)
             val.join(' ')
+          elsif val.is_a?(Hash)
+            val.map { |(k, v)| "#{k} #{v}" }.join("\n")
           elsif val.respond_to?(:to_s)
             to_s
           else

--- a/spec/features/formattable_spec.rb
+++ b/spec/features/formattable_spec.rb
@@ -111,5 +111,31 @@ describe 'Formattable features' do
 
       it_behaves_like 'a successful exec'
     end
+
+    context 'with to_ssv' do
+      let(:input) { load_fixture('json/table_simple_hash.json') }
+      let(:args) { 'json to_ssv' }
+      let(:expect_output) do
+        <<~OUTPUT
+          name Alice
+          age 30
+        OUTPUT
+      end
+
+      it_behaves_like 'a successful exec'
+    end
+
+    context 'with to_v (alias for to_ssv)' do
+      let(:input) { load_fixture('json/table_simple_hash.json') }
+      let(:args) { 'json to_v' }
+      let(:expect_output) do
+        <<~OUTPUT
+          name Alice
+          age 30
+        OUTPUT
+      end
+
+      it_behaves_like 'a successful exec'
+    end
   end
 end


### PR DESCRIPTION
Implement Hash#to_ssv and Hash#to_v methods with key-value pair formatting. Add tests to ensure proper functionality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)