### PR TITLE
Disable color output with -i option

### DIFF
--- a/mrblib/rf/cli.rb
+++ b/mrblib/rf/cli.rb
@@ -91,13 +91,7 @@ module Rf
 
     no_commands do # rubocop:disable Metrics/BlockLength
       def run(type, argv)
-        t = type == :grep ? :text : type
-        config = Config.from(t, options, argv)
-
-        if type == :grep
-          opt = config.ignore_case ? Regexp::IGNORECASE : nil
-          config.expressions = [Regexp.new(config.expressions.join('|'), opt)]
-        end
+        config = Config.from(type, options, argv)
 
         Runner.run(config)
       rescue Rf::NoExpression

--- a/spec/global_options/in_place_option_spec.rb
+++ b/spec/global_options/in_place_option_spec.rb
@@ -44,4 +44,27 @@ describe 'Behavior with in-place option' do
       it { expect(test2).to eq "bAc\n" }
     end
   end
+
+  describe 'color option is disabled with -i' do
+    before do
+      write_file('testfile', "foo\nbar\nfoo")
+    end
+
+    context 'when -i option is used' do
+      let(:args) { '-i /foo/ testfile' }
+      let(:expect_output) { '' }
+
+      it_behaves_like 'a successful exec' do
+        it 'disables color output automatically' do
+          # The -i option automatically disables color output
+          # File should be modified without ANSI escape sequences
+          expect(read_file('testfile')).to eq("foo\nfoo\n")
+        end
+
+        it 'does not include ANSI escape sequences in the file' do
+          expect(read_file('testfile')).not_to include("\e[")
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
Add automatic color disabling when using in-place editing to prevent ANSI escape sequences in modified files. Includes test coverage and refactored Config initialization.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

fix: #390 